### PR TITLE
Remove java.util.List explicit dependencies

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,27 @@
 # pylint: disable=R0801
 """Common methods and models for tests"""
+import os
+import sys
+
+myPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, myPath + "/../")
+
+import trustyai
+
+INITIALISED = False
+
+if not INITIALISED:
+    trustyai.init(
+        path=trustyai.CORE_DEPS + [
+            "./dep/org/optaplanner/optaplanner-core/8.12.0.Final/optaplanner-core-8.12.0.Final.jar",
+            "./dep/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
+            "./dep/org/kie/kie-api/7.59.0.Final/kie-api-7.59.0.Final.jar",
+            "./dep/io/micrometer/micrometer-core/1.7.4/micrometer-core-1.7.4.jar",
+        ]
+    )
+
+    INITIALISED = True
+
 from trustyai.model import (
     FeatureFactory,
     Output,

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,0 +1,27 @@
+# pylint: disable=import-error, wrong-import-position, wrong-import-order, invalid-name
+"""Implicit conversion test suite"""
+import sys
+import os
+
+from jpype import _jclass
+
+myPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, myPath + "/../")
+
+import trustyai
+
+trustyai.init()
+
+
+def test_list_python_to_java():
+    """Test Python to Java List conversion"""
+    python_list = [2, 4, 3, 5, 1]
+    minimum = _jclass.JClass('java.util.Collections').min(python_list)
+    assert minimum == 1
+
+
+def test_list_java_to_python():
+    """Test Java to Python List conversion"""
+    python_list = [2, 4, 3, 5, 1]
+    java_list = _jclass.JClass('java.util.Arrays').asList(python_list)
+    assert 15 == sum(java_list)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,16 +1,8 @@
 # pylint: disable=import-error, wrong-import-position, wrong-import-order, invalid-name
 """Implicit conversion test suite"""
-import sys
-import os
+from common import *
 
 from jpype import _jclass
-
-myPath = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, myPath + "/../")
-
-import trustyai
-
-trustyai.init()
 
 
 def test_list_python_to_java():

--- a/tests/test_counterfactualexplainer.py
+++ b/tests/test_counterfactualexplainer.py
@@ -1,29 +1,16 @@
 # pylint: disable=import-error, wrong-import-position, wrong-import-order, R0801
 """Test suite for counterfactual explanations"""
-import os
-import sys
+
+from common import *
+
 import uuid
-
-myPath = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, myPath + "/../")
-
-import trustyai
-
-trustyai.init(
-    path=trustyai.CORE_DEPS + [
-        "./dep/org/optaplanner/optaplanner-core/8.12.0.Final/optaplanner-core-8.12.0.Final.jar",
-        "./dep/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
-        "./dep/org/kie/kie-api/7.59.0.Final/kie-api-7.59.0.Final.jar",
-        "./dep/io/micrometer/micrometer-core/1.7.4/micrometer-core-1.7.4.jar",
-    ]
-)
 
 from trustyai.explainers import (
     CounterfactualExplainer,
     SolverConfigBuilder,
     CounterfactualConfig,
 )
-from trustyai.utils import TestUtils, toJList
+from trustyai.utils import TestUtils
 from trustyai.model.domain import NumericalFeatureDomain
 from trustyai.model import (
     CounterfactualPrediction,
@@ -104,7 +91,7 @@ def test_counterfactual_match():
     goal = [Output("inside", Type.BOOLEAN, Value(True), 0.0)]
 
     features = [
-        FeatureFactory.newNumericalFeature(f"f-num{i+1}", 10.0) for i in range(4)
+        FeatureFactory.newNumericalFeature(f"f-num{i + 1}", 10.0) for i in range(4)
     ]
     constraints = [False] * 4
     feature_boundaries = [NumericalFeatureDomain.create(0.0, 1000.0)] * 4

--- a/tests/test_datautils.py
+++ b/tests/test_datautils.py
@@ -1,16 +1,9 @@
 # pylint: disable=import-error, wrong-import-position, wrong-import-order, invalid-name
 """Data utils test suite"""
-import sys
-import os
+from common import *
+
 from pytest import approx
 import random
-
-myPath = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, myPath + "/../")
-
-import trustyai
-
-trustyai.init()
 
 from trustyai.utils import DataUtils
 from trustyai.model import PerturbationContext, FeatureFactory

--- a/tests/test_limeexplainer.py
+++ b/tests/test_limeexplainer.py
@@ -1,21 +1,9 @@
 # pylint: disable=import-error, wrong-import-position, wrong-import-order, duplicate-code
 """LIME explainer test suite"""
-import sys
-import os
+
+from common import *
+
 import pytest
-
-myPath = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, myPath + "/../")
-
-import trustyai
-
-trustyai.init(
-    path=trustyai.CORE_DEPS + [
-        "./dep/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
-        "./dep/org/kie/kie-api/7.55.0.Final/kie-api-7.55.0.Final.jar",
-        "./dep/io/micrometer/micrometer-core/1.6.6/micrometer-core-1.6.6.jar",
-    ]
-)
 
 DEFAULT_NO_OF_PERTURBATIONS = 1
 
@@ -41,10 +29,10 @@ def test_empty_prediction():
     """Check if the explanation returned is not null"""
     config = (
         LimeConfig()
-        .withPerturbationContext(
+            .withPerturbationContext(
             PerturbationContext(jrandom, DEFAULT_NO_OF_PERTURBATIONS)
         )
-        .withSamples(10)
+            .withSamples(10)
     )
     lime_explainer = LimeExplainer(config)
     input_ = PredictionInput([])
@@ -61,10 +49,10 @@ def test_non_empty_input():
     """Test for non-empty input"""
     config = (
         LimeConfig()
-        .withPerturbationContext(
+            .withPerturbationContext(
             PerturbationContext(jrandom, DEFAULT_NO_OF_PERTURBATIONS)
         )
-        .withSamples(10)
+            .withSamples(10)
     )
     lime_explainer = LimeExplainer(config)
     features = [FeatureFactory.newNumericalFeature(f"f-num{i}", i) for i in range(4)]
@@ -84,11 +72,11 @@ def test_sparse_balance():  # pylint: disable=too-many-locals
         no_of_samples = 100
         config_no_penalty = (
             LimeConfig()
-            .withPerturbationContext(
+                .withPerturbationContext(
                 PerturbationContext(jrandom, DEFAULT_NO_OF_PERTURBATIONS)
             )
-            .withSamples(no_of_samples)
-            .withPenalizeBalanceSparse(False)
+                .withSamples(no_of_samples)
+                .withPenalizeBalanceSparse(False)
         )
         lime_explainer_no_penalty = LimeExplainer(config_no_penalty)
 
@@ -130,9 +118,9 @@ def test_normalized_weights():
     """Test normalized weights"""
     config = (
         LimeConfig()
-        .withNormalizeWeights(True)
-        .withPerturbationContext(PerturbationContext(jrandom, 2))
-        .withSamples(10)
+            .withNormalizeWeights(True)
+            .withPerturbationContext(PerturbationContext(jrandom, 2))
+            .withSamples(10)
     )
     lime_explainer = LimeExplainer(config)
     n_features = 4

--- a/trustyai/__init__.py
+++ b/trustyai/__init__.py
@@ -4,7 +4,7 @@ from typing import List
 import uuid
 import jpype
 import jpype.imports
-from jpype import _jcustomizer
+from jpype import _jcustomizer, _jclass
 
 TRUSTY_VERSION = "1.12.0.Final"
 CORE_DEPS = [
@@ -29,11 +29,11 @@ def init(*args, path=CORE_DEPS):
         from java.util import UUID
 
         @_jcustomizer.JConversion("java.util.List", exact=List)
-        def _JSequenceConvert(_, obj):
-            return toJList(obj)
+        def _JListConvert(_, py_list: List):
+            return _jclass.JClass('java.util.Arrays').asList(py_list)
 
         @_jcustomizer.JConversion("java.util.UUID", instanceof=uuid.UUID)
-        def _JSequenceConvert(_, obj):
+        def _JUUIDConvert(_, obj):
             return UUID.fromString(str(obj))
 
     except OSError:

--- a/trustyai/__init__.py
+++ b/trustyai/__init__.py
@@ -25,7 +25,6 @@ def init(*args, path=CORE_DEPS):
         if not Thread.isAttached:
             jpype.attachThreadToJVM()
 
-        from trustyai.utils import toJList
         from java.util import UUID
 
         @_jcustomizer.JConversion("java.util.List", exact=List)

--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -1,6 +1,7 @@
 """Explainers module"""
 # pylint: disable = import-error, too-few-public-methods
 from typing import Dict
+
 from org.kie.kogito.explainability.local.counterfactual import (
     CounterfactualExplainer as _CounterfactualExplainer,
     CounterfactualResult,
@@ -26,7 +27,7 @@ class CounterfactualExplainer:
         self._explainer = _CounterfactualExplainer(config)
 
     def explain(
-        self, prediction: Prediction, model: PredictionProvider
+            self, prediction: Prediction, model: PredictionProvider
     ) -> CounterfactualResult:
         """Request for a counterfactual explanation given a prediction and a model"""
         return self._explainer.explainAsync(prediction, model).get()

--- a/trustyai/model/__init__.py
+++ b/trustyai/model/__init__.py
@@ -1,8 +1,9 @@
 # pylint: disable = import-error, too-few-public-methods, invalid-name, duplicate-code
 """General model classes"""
 from typing import List
+
 from java.util.concurrent import CompletableFuture, ForkJoinPool
-from jpype import JImplements, JOverride, JProxy, _jcustomizer
+from jpype import JImplements, JOverride, JProxy
 from org.kie.kogito.explainability.model import (
     CounterfactualPrediction as _CounterfactualPrediction,
     DataDomain as _DataDomain,
@@ -18,7 +19,6 @@ from org.kie.kogito.explainability.model import (
     Value as _Value,
     Type as _Type,
 )
-from trustyai.utils import toJList
 
 CounterfactualPrediction = _CounterfactualPrediction
 DataDomain = _DataDomain

--- a/trustyai/utils/DataUtils.py
+++ b/trustyai/utils/DataUtils.py
@@ -1,7 +1,6 @@
 # pylint: disable = invalid-name, import-error
 """DataUtils module"""
 from org.kie.kogito.explainability.utils import DataUtils as du
-from java.util import ArrayList
 
 getMean = du.getMean
 getStdDev = du.getStdDev
@@ -20,18 +19,15 @@ def generateData(mean, stdDeviation, size, jrandom):
 
 def perturbFeatures(originalFeatures, perturbationContext):
     """Perform perturbations on a fixed number of features in the given input."""
-    jlist = ArrayList(originalFeatures)
-    return du.perturbFeatures(jlist, perturbationContext)
+    return du.perturbFeatures(originalFeatures, perturbationContext)
 
 
 def getLinearizedFeatures(originalFeatures):
     """Transform a list of eventually composite / nested features into a
     flat list of non composite / non nested features."""
-    jlist = ArrayList(originalFeatures)
-    return du.getLinearizedFeatures(jlist)
+    return du.getLinearizedFeatures(originalFeatures)
 
 
 def sampleWithReplacement(values, sampleSize, jrandom):
     """Sample (with replacement) from a list of values."""
-    jlist = ArrayList(values)
-    return du.sampleWithReplacement(jlist, sampleSize, jrandom)
+    return du.sampleWithReplacement(values, sampleSize, jrandom)

--- a/trustyai/utils/__init__.py
+++ b/trustyai/utils/__init__.py
@@ -4,15 +4,6 @@ from org.kie.kogito.explainability import (
     TestUtils as _TestUtils,
     Config as _Config,
 )
-from java.util import ArrayList, List
 
 TestUtils = _TestUtils
 Config = _Config
-
-
-def toJList(pyList):
-    """Convert a Python list to a Java ArrayList"""
-    result = ArrayList()
-    for item in pyList:
-        result.add(item)
-    return result


### PR DESCRIPTION
https://github.com/trustyai-python/module/issues/10

- Added new Python/Java list converter
- Remove all `toJList` explicit dependencies
- Fix implicit converters names
- Added unit tests for conversions