### PR TITLE
Add ability to create FeatureDomains from native Python collections

### DIFF
--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,8 +1,11 @@
 # pylint: disable=import-error, wrong-import-position, wrong-import-order, invalid-name
 """Implicit conversion test suite"""
+
 from common import *
 
 from jpype import _jclass
+
+from trustyai.model.domain import feature_domain
 
 
 def test_list_python_to_java():
@@ -17,3 +20,35 @@ def test_list_java_to_python():
     python_list = [2, 4, 3, 5, 1]
     java_list = _jclass.JClass('java.util.Arrays').asList(python_list)
     assert 15 == sum(java_list)
+
+
+def test_numeric_domain_tuple():
+    """Test create numeric domain from tuple"""
+    domain = (0, 1000)
+    jdomain = feature_domain(domain)
+    assert jdomain.getLowerBound() == 0
+    assert jdomain.getUpperBound() == 1000
+
+    domain = (0.0, 1000.0)
+    jdomain = feature_domain(domain)
+    assert jdomain.getLowerBound() == 0.0
+    assert jdomain.getUpperBound() == 1000.0
+
+
+def test_empty_domain():
+    """Test empty domain"""
+    domain = feature_domain(None)
+    assert domain.isEmpty() is True
+
+
+def test_categorical_domain_tuple():
+    """Test create categorical domain from tuple and list"""
+    domain = ("foo", "bar", "baz")
+    jdomain = feature_domain(domain)
+    assert jdomain.getCategories().size() == 3
+    assert jdomain.getCategories().containsAll(list(domain))
+
+    domain = ["foo", "bar", "baz"]
+    jdomain = feature_domain(domain)
+    assert jdomain.getCategories().size() == 3
+    assert jdomain.getCategories().containsAll(domain)

--- a/tests/test_counterfactualexplainer.py
+++ b/tests/test_counterfactualexplainer.py
@@ -9,7 +9,6 @@ from trustyai.model import (
     FeatureFactory,
     output,
 )
-from trustyai.model.domain import NumericalFeatureDomain
 from trustyai.utils import TestUtils
 
 jrandom = Random()
@@ -27,7 +26,7 @@ def test_non_empty_input():
         for i in range(n_features)
     ]
     constraints = [False] * n_features
-    domains = [NumericalFeatureDomain.create(0.0, 1000.0)] * n_features
+    domains = [(0.0, 1000.0)] * n_features
 
     model = TestUtils.getSumSkipModel(0)
 
@@ -52,7 +51,7 @@ def test_counterfactual_match():
         FeatureFactory.newNumericalFeature(f"f-num{i + 1}", 10.0) for i in range(4)
     ]
     constraints = [False] * 4
-    domains = [NumericalFeatureDomain.create(0.0, 1000.0)] * 4
+    domains = [(0.0, 1000.0)] * 4
 
     center = 500.0
     epsilon = 10.0

--- a/trustyai/model/domain.py
+++ b/trustyai/model/domain.py
@@ -1,8 +1,29 @@
-# pylint: disable=import-error
-"""Domain objects"""
+# pylint: disable = import-error
+"""Conversion method between Python and TrustyAI Java types"""
+from typing import Optional, Tuple, List, Union
 
+from jpype import _jclass
 from org.kie.kogito.explainability.model.domain import (
-    NumericalFeatureDomain as _NumericalFeatureDomain,
+    FeatureDomain,
+    NumericalFeatureDomain,
+    CategoricalFeatureDomain,
+    EmptyFeatureDomain,
 )
 
-NumericalFeatureDomain = _NumericalFeatureDomain
+
+def feature_domain(
+    values: Optional[Union[Tuple, List[str]]]
+) -> Optional[FeatureDomain]:
+    """Create Java FeatureDomain from a Python tuple or list"""
+    if not values:
+        domain = EmptyFeatureDomain.create()
+    else:
+        if isinstance(values[0], (float, int)):
+            domain = NumericalFeatureDomain.create(values[0], values[1])
+        elif isinstance(values[0], str):
+            domain = CategoricalFeatureDomain.create(
+                _jclass.JClass("java.util.Arrays").asList(values)
+            )
+        else:
+            domain = EmptyFeatureDomain.create()
+    return domain


### PR DESCRIPTION
Closes https://github.com/trustyai-python/module/issues/32

- Feature domains can be create from `Tuple` of `int`, `float` or `str` and `List` of `str`
- `None` is interpreted as `EmptyFeatureDomain`
- `CounterfactualPrediction` accepts lists of the above (no need to create Java object directly)



