### PR TITLE
Replace TrustyAI factory methods with type inference

### DIFF
--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -5,7 +5,9 @@ from common import *
 
 from jpype import _jclass
 
+from trustyai.model import feature
 from trustyai.model.domain import feature_domain
+from org.kie.kogito.explainability.model import Type
 
 
 def test_list_python_to_java():
@@ -52,3 +54,21 @@ def test_categorical_domain_tuple():
     jdomain = feature_domain(domain)
     assert jdomain.getCategories().size() == 3
     assert jdomain.getCategories().containsAll(domain)
+
+
+def test_feature_function():
+    """Test helper method to create features"""
+    f1 = feature(name="f-1", value=1.0, dtype="number")
+    assert f1.name == "f-1"
+    assert f1.value.as_number() == 1.0
+    assert f1.type == Type.NUMBER
+
+    f2 = feature(name="f-2", value=True, dtype="bool")
+    assert f2.name == "f-2"
+    assert f2.value.as_obj() == True
+    assert f2.type == Type.BOOLEAN
+
+    f3 = feature(name="f-3", value="foo", dtype="categorical")
+    assert f3.name == "f-3"
+    assert f3.value.as_string() == "foo"
+    assert f3.type == Type.CATEGORICAL

--- a/tests/test_counterfactualexplainer.py
+++ b/tests/test_counterfactualexplainer.py
@@ -10,7 +10,7 @@ from trustyai.explainers import CounterfactualExplainer
 from trustyai.local.counterfactual import counterfactual_prediction
 from trustyai.model import (
     FeatureFactory,
-    output, Model,
+    output, Model, feature,
 )
 from trustyai.utils import TestUtils
 
@@ -25,7 +25,7 @@ def test_non_empty_input():
 
     goal = [output(name="f-num1", dtype="number", value=10.0, score=0.0)]
     features = [
-        FeatureFactory.newNumericalFeature(f"f-num{i}", i * 2.0)
+        feature(name=f"f-num{i}", value=i * 2.0, dtype="number")
         for i in range(n_features)
     ]
     domains = [(0.0, 1000.0)] * n_features
@@ -49,7 +49,7 @@ def test_counterfactual_match():
     goal = [output(name="inside", dtype="bool", value=True, score=0.0)]
 
     features = [
-        FeatureFactory.newNumericalFeature(f"f-num{i + 1}", 10.0) for i in range(4)
+        feature(name=f"f-num{i + 1}", value=10.0, dtype="number") for i in range(4)
     ]
     domains = [(0.0, 1000.0)] * 4
 
@@ -87,7 +87,7 @@ def test_counterfactual_match_python_model():
     n_features = 5
 
     features = [
-        FeatureFactory.newNumericalFeature(f"f-num{i + 1}", 10.0) for i in range(n_features)
+        feature(name=f"f-num{i + 1}", value=10.0, dtype="number") for i in range(n_features)
     ]
     domains = [(0.0, 1000.0)] * n_features
 
@@ -111,7 +111,7 @@ def test_default_constraints():
     n_features = 5
 
     features = [
-        FeatureFactory.newNumericalFeature(f"f-num{i + 1}", 10.0) for i in range(n_features)
+        feature(name=f"f-num{i + 1}", value=10.0, dtype="number") for i in range(n_features)
     ]
     domains = [(0.0, 1000.0)] * n_features
 
@@ -126,7 +126,7 @@ def test_default_constraints():
     n_features = 10
 
     features = [
-        FeatureFactory.newNumericalFeature(f"f-num{i + 1}", 10.0) for i in range(n_features)
+        feature(name=f"f-num{i + 1}", value=10.0, dtype="number") for i in range(n_features)
     ]
     domains = [(0.0, 1000.0)] * n_features
 

--- a/tests/test_limeexplainer.py
+++ b/tests/test_limeexplainer.py
@@ -9,9 +9,7 @@ from common import mock_feature
 from trustyai.explainers import LimeExplainer
 from trustyai.local.counterfactual import simple_prediction
 from trustyai.utils import TestUtils
-from trustyai.model import (
-    FeatureFactory,
-)
+from trustyai.model import feature
 
 from org.kie.kogito.explainability.local import (
     LocalExplanationException,
@@ -36,7 +34,7 @@ def test_empty_prediction():
 def test_non_empty_input():
     """Test for non-empty input"""
     lime_explainer = LimeExplainer(seed=0, samples=10, perturbations=1)
-    features = [FeatureFactory.newNumericalFeature(f"f-num{i}", i) for i in range(4)]
+    features = [feature(name=f"f-num{i}", value=i, dtype="number") for i in range(4)]
 
     model = TestUtils.getSumSkipModel(0)
     outputs = model.predict([features])[0].outputs

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,9 +3,7 @@
 
 from common import *
 
-from trustyai.model import Model
-
-from org.kie.kogito.explainability.model import FeatureFactory
+from trustyai.model import Model, feature
 
 
 def foo():
@@ -23,7 +21,7 @@ def test_basic_model():
     model = Model(test_model)
 
     features = [
-        FeatureFactory.newNumericalFeature(f"f-num{i}", i * 2.0)
+        feature(name=f"f-num{i}", value=i * 2.0, dtype="number")
         for i in range(5)
     ]
 

--- a/trustyai/model/__init__.py
+++ b/trustyai/model/__init__.py
@@ -7,7 +7,7 @@ from jpype import JImplements, JOverride, _jcustomizer, _jclass
 from org.kie.kogito.explainability.model import (
     CounterfactualPrediction as _CounterfactualPrediction,
     DataDomain as _DataDomain,
-    Feature as _Feature,
+    Feature,
     FeatureFactory as _FeatureFactory,
     Output as _Output,
     PredictionFeatureDomain as _PredictionFeatureDomain,
@@ -24,7 +24,6 @@ from org.kie.kogito.explainability.local.counterfactual.entities import (
 
 CounterfactualPrediction = _CounterfactualPrediction
 DataDomain = _DataDomain
-Feature = _Feature
 FeatureFactory = _FeatureFactory
 Output = _Output
 PredictionFeatureDomain = _PredictionFeatureDomain
@@ -175,6 +174,10 @@ class _JValue:
         """Return as number"""
         return self.asNumber()
 
+    def as_obj(self):
+        """Return as object"""
+        return self.getUnderlyingObject()
+
     def __str__(self):
         return self.toString()
 
@@ -243,7 +246,7 @@ class _JPredictionFeatureDomain:
         return self.getFeatureDomains()
 
 
-def output(name, dtype, value=None, score=1.0):
+def output(name, dtype, value=None, score=1.0) -> _Output:
     """Helper method returning a Java Output"""
     if dtype == "text":
         _type = Type.TEXT
@@ -256,3 +259,16 @@ def output(name, dtype, value=None, score=1.0):
     else:
         _type = Type.UNDEFINED
     return _Output(name, _type, Value(value), score)
+
+
+def feature(name: str, dtype: str, value=None) -> Feature:
+    """Helper method to build features"""
+    if dtype == "categorical":
+        _feature = FeatureFactory.newCategoricalFeature(name, value)
+    elif dtype == "number":
+        _feature = FeatureFactory.newNumericalFeature(name, value)
+    elif dtype == "bool":
+        _feature = FeatureFactory.newBooleanFeature(name, value)
+    else:
+        _feature = FeatureFactory.newObjectFeature(name, value)
+    return _feature


### PR DESCRIPTION
Replace trustyai factory methods with type inference. Closes https://github.com/trustyai-python/module/issues/19