### PR TITLE
Add post-install command to get Java dependencies

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,10 +28,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
-      - name: Download JARs
-        run: |
-          chmod +x ./deps.sh
-          ./deps.sh
+          python setup.py build install
       - name: Lint
         run: |
           pylint --ignore-imports=yes $(find trustyai -type f -name "*.py")

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,29 @@
 import os
 from setuptools import setup
+from setuptools.command.install import install
+import site
 
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
+
+TRUSTY_VERSION = "1.12.0.Final"
+
+
+class PostInstall(install):
+    """Fetch TrustyAI explainability JARs from Maven Central"""
+
+    def run(self):
+        install.run(self)
+        _ROOT = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
+        print(f"Installing Maven dependencies into {_ROOT}")
+        os.system(f"mvn org.apache.maven.plugins:maven-dependency-plugin:2.10:get "
+                  f"-DremoteRepositories=https://repository.sonatype.org/content/repositories/central  "
+                  f"-Dartifact=org.kie.kogito:explainability-core:{TRUSTY_VERSION} -Dmaven.repo.local={_ROOT} -q")
+        _TESTS_FILE = os.path.join("org", "kie", "kogito", "explainability-core", TRUSTY_VERSION,
+                                   f"explainability-core-{TRUSTY_VERSION}-tests.jar")
+        os.system(f"wget -O {os.path.join(_ROOT, _TESTS_FILE)} https://repo1.maven.org/maven2/{_TESTS_FILE}")
+
 
 setup(
     name="trustyai",
@@ -29,4 +49,5 @@ setup(
     packages=['trustyai', 'trustyai.model', 'trustyai.utils', 'trustyai.local'],
     include_package_data=False,
     install_requires=['Jpype1'],
+    cmdclass={"install": PostInstall},
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -12,15 +12,7 @@ import trustyai
 INITIALISED = False
 
 if not INITIALISED:
-    trustyai.init(
-        path=trustyai.CORE_DEPS + [
-            f"{trustyai.DEFAULT_DEP_PATH}/org/optaplanner/optaplanner-core/8.12.0.Final/optaplanner-core-8.12.0.Final.jar",
-            f"{trustyai.DEFAULT_DEP_PATH}/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
-            f"{trustyai.DEFAULT_DEP_PATH}/org/kie/kie-api/7.59.0.Final/kie-api-7.59.0.Final.jar",
-            f"{trustyai.DEFAULT_DEP_PATH}/io/micrometer/micrometer-core/1.7.4/micrometer-core-1.7.4.jar",
-        ]
-    )
-
+    trustyai.init()
     INITIALISED = True
 
 from trustyai.model import (

--- a/tests/common.py
+++ b/tests/common.py
@@ -14,10 +14,10 @@ INITIALISED = False
 if not INITIALISED:
     trustyai.init(
         path=trustyai.CORE_DEPS + [
-            "./dep/org/optaplanner/optaplanner-core/8.12.0.Final/optaplanner-core-8.12.0.Final.jar",
-            "./dep/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
-            "./dep/org/kie/kie-api/7.59.0.Final/kie-api-7.59.0.Final.jar",
-            "./dep/io/micrometer/micrometer-core/1.7.4/micrometer-core-1.7.4.jar",
+            f"{trustyai.DEFAULT_DEP_PATH}/org/optaplanner/optaplanner-core/8.12.0.Final/optaplanner-core-8.12.0.Final.jar",
+            f"{trustyai.DEFAULT_DEP_PATH}/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
+            f"{trustyai.DEFAULT_DEP_PATH}/org/kie/kie-api/7.59.0.Final/kie-api-7.59.0.Final.jar",
+            f"{trustyai.DEFAULT_DEP_PATH}/io/micrometer/micrometer-core/1.7.4/micrometer-core-1.7.4.jar",
         ]
     )
 

--- a/trustyai/__init__.py
+++ b/trustyai/__init__.py
@@ -1,12 +1,12 @@
 # pylint: disable = import-error, import-outside-toplevel, dangerous-default-value, invalid-name, R0801
 """Main TrustyAI Python bindings"""
 from typing import List
+import site
+import os
 import uuid
 import jpype
 import jpype.imports
 from jpype import _jcustomizer, _jclass
-import site
-import os
 
 TRUSTY_VERSION = "1.12.0.Final"
 DEFAULT_DEP_PATH = os.path.join(site.getsitepackages()[0], "trustyai", "dep")

--- a/trustyai/__init__.py
+++ b/trustyai/__init__.py
@@ -15,6 +15,11 @@ CORE_DEPS = [
     f"{DEFAULT_DEP_PATH}/org/kie/kogito/explainability-core/{TRUSTY_VERSION}/*",
     f"{DEFAULT_DEP_PATH}/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar",
     f"{DEFAULT_DEP_PATH}/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+    f"{DEFAULT_DEP_PATH}/org/optaplanner/optaplanner-core/8.12.0.Final/"
+    f"optaplanner-core-8.12.0.Final.jar",
+    f"{DEFAULT_DEP_PATH}/org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
+    f"{DEFAULT_DEP_PATH}/org/kie/kie-api/7.59.0.Final/kie-api-7.59.0.Final.jar",
+    f"{DEFAULT_DEP_PATH}/io/micrometer/micrometer-core/1.7.4/micrometer-core-1.7.4.jar",
 ]
 
 

--- a/trustyai/__init__.py
+++ b/trustyai/__init__.py
@@ -5,12 +5,16 @@ import uuid
 import jpype
 import jpype.imports
 from jpype import _jcustomizer, _jclass
+import site
+import os
 
 TRUSTY_VERSION = "1.12.0.Final"
+DEFAULT_DEP_PATH = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
+
 CORE_DEPS = [
-    f"./dep/org/kie/kogito/explainability-core/{TRUSTY_VERSION}/*",
-    "./dep/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar",
-    "./dep/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+    f"{DEFAULT_DEP_PATH}/org/kie/kogito/explainability-core/{TRUSTY_VERSION}/*",
+    f"{DEFAULT_DEP_PATH}/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar",
+    f"{DEFAULT_DEP_PATH}/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
 ]
 
 


### PR DESCRIPTION
This PR adds a post-install script which:
-  fetches the Java dependencies on `pip install`
- Installs them on `site-packages`

These JARs will be available in `virtualenvs` too.
The JARs fetched will be for a certain Kogito version which will be bumped when needed.

The JARs will be considered the "default" ones and the module can be initialised with

```python
import trustyai

trustyai.init()
```

If custom JARs need to used, the default ones can be overridden with

```python
import trustyai

trustyai.init(path=[ # list of paths to my JARs ]) 
```