### PR TITLE
[FAI-762] Standardise visualisation API across explainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.2.2-green) ![TrustyAI](https://img.shields.io/badge/TrustyAI-1.20-green) [![Tests](https://github.com/trustyai-python/module/actions/workflows/workflow.yml/badge.svg)](https://github.com/trustyai-python/examples/actions/workflows/workflow.yml)
+![version](https://img.shields.io/badge/version-0.2.3-green) ![TrustyAI](https://img.shields.io/badge/TrustyAI-1.20-green) [![Tests](https://github.com/trustyai-python/module/actions/workflows/workflow.yml/badge.svg)](https://github.com/trustyai-python/examples/actions/workflows/workflow.yml)
 
 # python-trustyai
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PostInstall(install):
 
 setup(
     name="trustyai",
-    version="0.2.2",
+    version="0.2.3",
     description="Python bindings to the TrustyAI explainability library",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_counterfactualexplainer.py
+++ b/tests/test_counterfactualexplainer.py
@@ -35,7 +35,7 @@ def test_non_empty_input():
     )
 
     counterfactual_result = explainer.explain(prediction, model)
-    for entity in counterfactual_result.entities:
+    for entity in counterfactual_result._result.entities:
         print(entity)
         assert entity is not None
 
@@ -61,16 +61,16 @@ def test_counterfactual_match():
     result = explainer.explain(prediction, model)
 
     total_sum = 0
-    for entity in result.entities:
+    for entity in result._result.entities:
         total_sum += entity.as_feature().value.as_number()
         print(entity)
 
     print("Counterfactual match:")
-    print(result.output[0].outputs)
+    print(result._result.output[0].outputs)
 
     assert total_sum <= center + epsilon
     assert total_sum >= center - epsilon
-    assert result.isValid()
+    assert result._result.isValid()
 
 
 def test_counterfactual_match_python_model():
@@ -94,4 +94,4 @@ def test_counterfactual_match_python_model():
     model = Model(sum_skip_model)
 
     result = explainer.explain(prediction, model)
-    assert sum([entity.as_feature().value.as_number() for entity in result.entities]) == approx(GOAL_VALUE, rel=3)
+    assert sum([entity.as_feature().value.as_number() for entity in result._result.entities]) == approx(GOAL_VALUE, rel=3)

--- a/tests/test_shap.py
+++ b/tests/test_shap.py
@@ -71,5 +71,5 @@ def test_shap_plots():
     shap_explainer = SHAPExplainer(background=background)
     explanation = shap_explainer.explain(prediction, model)
 
-    explanation.visualize_as_dataframe()
-    explanation.visualize_as_candlestick_plot()
+    explanation.as_dataframe()
+    explanation.candlestick_plot()

--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -215,9 +215,9 @@ class SHAPResults(ExplanationVisualiser):
             formats = []
             for i, feature_value in enumerate(feature_values[1:-1]):
                 if feature_value < background_vals[i]:
-                    formats.append("background-color:#ee0000")
+                    formats.append(f"background-color:{ds['negative_primary_colour']}")
                 elif feature_value > background_vals[i]:
-                    formats.append("background-color:#13ba3c")
+                    formats.append(f"background-color:{ds['positive_primary_colour']}")
                 else:
                     formats.append(None)
             return [None] + formats + [None]

--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -62,7 +62,7 @@ class CounterfactualResult(ExplanationVisualiser):
         dfr["difference"] = dfr.proposed - dfr.original
         return dfr
 
-    def as_html(self) -> None:
+    def as_html(self) -> Styler:
         """Returned styled dataframe"""
         return self.as_dataframe().style
 
@@ -329,7 +329,7 @@ class SHAPResults(ExplanationVisualiser):
                 vmax=max(np.abs(shap_values)),
             )
             style.set_caption(f"Explanation of {saliency.getOutput().getName()}")
-            return visualizer_data_frame.style.apply(
+            return style.apply(
                 _color_feature_values,
                 background_vals=background_mean_feature_values,
                 subset="Feature Value",

--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -68,11 +68,11 @@ class CounterfactualResult(ExplanationVisualiser):
 
         def change_colour(value):
             if value == 0.0:
-                colour = "white"
+                colour = ds["neutral_primary_colour"]
             elif value > 0:
-                colour = "green"
+                colour = ds["positive_primary_colour"]
             else:
-                colour = "red"
+                colour = ds["negative_primary_colour"]
             return colour
 
         colour = _df["difference"].transform(change_colour)

--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -67,7 +67,7 @@ class CounterfactualExplainer:
         return self._explainer.explainAsync(prediction, model).get()
 
 
-class LimeExplanation:
+class LimeResults:
     """Encapsulate LIME results"""
 
     def __init__(self, saliencies: Dict[str, Saliency]):
@@ -96,13 +96,14 @@ class LimeExplanation:
                 feature_importance.getFeature().name
             ] = feature_importance.getScore()
 
-        colours = ["r" if i < 0 else "g" for i in dictionary.values()]
-        plt.title(f"LIME explanation for '{decision}'")
+        colours = [ds["negative_primary_colour"] if i < 0 else ds["positive_primary_colour"] for i in dictionary.values()]
+        plt.title(f"LIME explanation of {decision}")
         plt.barh(
             range(len(dictionary)), dictionary.values(), align="center", color=colours
         )
         plt.yticks(range(len(dictionary)), list(dictionary.keys()))
         plt.tight_layout()
+        plt.show()
 
 
 # pylint: disable=too-many-arguments
@@ -133,9 +134,9 @@ class LimeExplainer:
 
         self._explainer = _LimeExplainer(self._lime_config)
 
-    def explain(self, prediction, model: PredictionProvider) -> LimeExplanation:
+    def explain(self, prediction, model: PredictionProvider) -> LimeResults:
         """Request for a LIME explanation given a prediction and a model"""
-        return LimeExplanation(self._explainer.explainAsync(prediction, model).get())
+        return LimeResults(self._explainer.explainAsync(prediction, model).get())
 
 
 # pylint: disable=invalid-name

--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -63,7 +63,21 @@ class CounterfactualResult(ExplanationVisualiser):
         return dfr
 
     def plot(self):
-        pass
+        """Plot counterfactual"""
+        df = self.as_dataframe().copy()
+        df = df[df["difference"]!=0.0]
+
+        def change_colour(x):
+            if x == 0.0:
+                return "white"
+            elif x > 0:
+                return "green"
+            else:
+                return "red"
+
+        colour = df['difference'].transform(change_colour)
+        p = df[["features", "proposed", "original"]].plot.barh(x="features", color={"proposed": colour, "original": "black"})
+        p.set_title("Counterfactual")
 
 class CounterfactualExplainer:
     """Wrapper for TrustyAI's counterfactual explainer"""

--- a/trustyai/utils/_visualisation.py
+++ b/trustyai/utils/_visualisation.py
@@ -3,15 +3,17 @@ from abc import ABC, abstractmethod
 import pandas as pd
 
 
+# pylint: disable=too-few-public-methods
 class ExplanationVisualiser(ABC):
+    """Abstract class for explanation visualisers"""
+
     @abstractmethod
     def as_dataframe(self) -> pd.DataFrame:
         """Display explanation result as a dataframe"""
-        pass
 
 
 DEFAULT_STYLE = {
     "positive_primary_colour": "#13ba3c",
     "negative_primary_colour": "#ee0000",
-    "neutral_primary_colour": "#ffffff"
+    "neutral_primary_colour": "#ffffff",
 }

--- a/trustyai/utils/_visualisation.py
+++ b/trustyai/utils/_visualisation.py
@@ -1,7 +1,7 @@
 """Visualiser utilies for explainer results"""
 from abc import ABC, abstractmethod
 import pandas as pd
-
+from pandas.io.formats.style import Styler
 
 # pylint: disable=too-few-public-methods
 class ExplanationVisualiser(ABC):
@@ -10,6 +10,10 @@ class ExplanationVisualiser(ABC):
     @abstractmethod
     def as_dataframe(self) -> pd.DataFrame:
         """Display explanation result as a dataframe"""
+
+    @abstractmethod
+    def as_html(self) -> Styler:
+        """Visualise the styled dataframe"""
 
 
 DEFAULT_STYLE = {

--- a/trustyai/utils/_visualisation.py
+++ b/trustyai/utils/_visualisation.py
@@ -8,3 +8,10 @@ class ExplanationVisualiser(ABC):
     def as_dataframe(self) -> pd.DataFrame:
         """Display explanation result as a dataframe"""
         pass
+
+
+DEFAULT_STYLE = {
+    "positive_primary_colour": "#13ba3c",
+    "negative_primary_colour": "#ee0000",
+    "neutral_primary_colour": "#ffffff"
+}

--- a/trustyai/utils/_visualisation.py
+++ b/trustyai/utils/_visualisation.py
@@ -1,0 +1,10 @@
+"""Visualiser utilies for explainer results"""
+from abc import ABC, abstractmethod
+import pandas as pd
+
+
+class ExplanationVisualiser(ABC):
+    @abstractmethod
+    def as_dataframe(self) -> pd.DataFrame:
+        """Display explanation result as a dataframe"""
+        pass


### PR DESCRIPTION
[FAI-762](https://issues.redhat.com/browse/FAI-762):

Common API for the visualisation methods.

- Abstract class for visualiser's common code and API
- SHAP, LIME and CF support `as_dataframe` method
- LIME and CF support `.plot()` method
- SHAP supports `candlestick_plot()` (future plots under `{waterfall, candlestick, ...}_plot()`
- Basic support for styles using pre-defined dict keys