### PR TITLE
chore: Bump release 0.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.6.2-green) [![Tests](https://github.com/trustyai-python/module/actions/workflows/workflow.yml/badge.svg)](https://github.com/trustyai-python/examples/actions/workflows/workflow.yml)
+![version](https://img.shields.io/badge/version-0.6.3-green) [![Tests](https://github.com/trustyai-python/module/actions/workflows/workflow.yml/badge.svg)](https://github.com/trustyai-python/examples/actions/workflows/workflow.yml)
 
 # python-trustyai
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustyai"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python bindings to the TrustyAI explainability library."
 authors = [{ name = "Rui Vieira", email = "rui@redhat.com" }]
 license = { text = "Apache License Version 2.0" }

--- a/src/trustyai/version.py
+++ b/src/trustyai/version.py
@@ -1,3 +1,3 @@
 """TrustyAI version"""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"


### PR DESCRIPTION
## Summary by Sourcery

Bump the project to release version 0.6.3 across code and documentation references.

Documentation:
- Update README version badge to reflect release 0.6.3.

Chores:
- Update project metadata and internal version constant to 0.6.3.