### PR TITLE
chore: Bump release 0.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![version](https://img.shields.io/badge/version-0.6.3-green) [![Tests](https://github.com/trustyai-python/module/actions/workflows/workflow.yml/badge.svg)](https://github.com/trustyai-python/examples/actions/workflows/workflow.yml)
+![version](https://img.shields.io/badge/version-0.6.4-green) [![Tests](https://github.com/trustyai-python/module/actions/workflows/workflow.yml/badge.svg)](https://github.com/trustyai-python/examples/actions/workflows/workflow.yml)
 
 # python-trustyai
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "trustyai"
-version = "0.6.3"
+version = "0.6.4"
 description = "Python bindings to the TrustyAI explainability library."
 authors = [{ name = "Rui Vieira", email = "rui@redhat.com" }]
 license = { text = "Apache License Version 2.0" }

--- a/src/trustyai/utils/tokenizers.py
+++ b/src/trustyai/utils/tokenizers.py
@@ -8,5 +8,6 @@ from opennlp.tools.tokenize import SimpleTokenizer as _SimpleTokenizer
 CommonsStringTokenizer = _StringTokenizer
 
 
-def OpenNLPTokenizer():
+def OpenNLPTokenizer():  # pylint: disable=invalid-name
+    """Return the OpenNLP SimpleTokenizer singleton (2.x API)."""
     return _SimpleTokenizer.INSTANCE

--- a/src/trustyai/utils/tokenizers.py
+++ b/src/trustyai/utils/tokenizers.py
@@ -6,4 +6,7 @@ from org.apache.commons.text import StringTokenizer as _StringTokenizer
 from opennlp.tools.tokenize import SimpleTokenizer as _SimpleTokenizer
 
 CommonsStringTokenizer = _StringTokenizer
-OpenNLPTokenizer = _SimpleTokenizer
+
+
+def OpenNLPTokenizer():
+    return _SimpleTokenizer.INSTANCE

--- a/src/trustyai/utils/tyrus.py
+++ b/src/trustyai/utils/tyrus.py
@@ -270,7 +270,7 @@ class Tyrus:
             data_source["Tooltip " + output_names[i]] = data_source[
                 ["Tooltip Raw", output_column_name, "Unchanged"]
             ].apply(
-                lambda x: format_cf_tooltip(x[0], output_column_name, x[1], x[2]), 1
+                lambda x: format_cf_tooltip(x.iloc[0], output_column_name, x.iloc[1], x.iloc[2]), 1
             )
 
         self.cf_data_source = data_source

--- a/src/trustyai/utils/tyrus.py
+++ b/src/trustyai/utils/tyrus.py
@@ -270,7 +270,10 @@ class Tyrus:
             data_source["Tooltip " + output_names[i]] = data_source[
                 ["Tooltip Raw", output_column_name, "Unchanged"]
             ].apply(
-                lambda x: format_cf_tooltip(x.iloc[0], output_column_name, x.iloc[1], x.iloc[2]), 1
+                lambda x: format_cf_tooltip(
+                    x.iloc[0], output_column_name, x.iloc[1], x.iloc[2]
+                ),
+                1,
             )
 
         self.cf_data_source = data_source

--- a/src/trustyai/version.py
+++ b/src/trustyai/version.py
@@ -1,3 +1,3 @@
 """TrustyAI version"""
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"


### PR DESCRIPTION
## Summary by Sourcery

Bump the project to release version 0.6.4 across code and documentation.

Enhancements:
- Update internal __version__ constant to 0.6.4.

Build:
- Update project version in pyproject.toml to 0.6.4.

Documentation:
- Update README version badge to reflect release 0.6.4.